### PR TITLE
Add missing cryptography dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "argparse",
     "asyncio",
+    "cryptography",
     "secp256k1",
     "websockets"
 ]


### PR DESCRIPTION
Fixes

```
→ nostpy-cli 
Traceback (most recent call last):
  File "/home/juergen/ghq/github.com/UTXOnly/nostpy-cli/.venv/bin/nostpy-cli", line 5, in <module>
    from nostpy_cli.main import main
  File "/home/juergen/ghq/github.com/UTXOnly/nostpy-cli/nostpy_cli/main.py", line 7, in <module>
    from .kind4 import Kind4MessageCodec
  File "/home/juergen/ghq/github.com/UTXOnly/nostpy-cli/nostpy_cli/kind4.py", line 5, in <module>
    from cryptography.hazmat.backends import default_backend
ModuleNotFoundError: No module named 'cryptography'

```