### PR TITLE
send_event: Remove mandatory public_key command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Once installed, you can run `nostpy-cli` from the command line as shown below:
 To send an event:
 
 ```
-nostpy-cli send_event -pubkey "your_public_key_hex" -privkey "your_private_key_hex" -content "your plaintext message" -tags "[['tag1', 'value1']]" -kind 4 --relay "wss://yourrelayurl.com" "wss://yoursecondrelayurl.com"
+nostpy-cli send_event -privkey "your_private_key_hex" -content "your plaintext message" -tags "[['tag1', 'value1']]" -kind 4 --relay "wss://yourrelayurl.com" "wss://yoursecondrelayurl.com"
 ```
-`--pubkey` , `--priv_key` and `--relay` arguments are required, all else are optional
+`--priv_key` and `--relay` arguments are required, all else are optional
 
 #### Example
 * Send a kind 1 event with tags
@@ -58,7 +58,7 @@ nostpy-cli send_event -pubkey 5ce5b352f1ef76b1dffc5694dd5b34126137184cc9a7d78cba
 
 * Send a kind 4 direct message
 ```
-nostpy-cli send_event -pubkey 5ce5b352f1ef76b1dffc5694dd5b34126137184cc9a7d78cba841c0635e17952 -privkey 2b1e4e1f26517dda57458596760bb3bd3bd3717083763166e12983a6421abc18 -content "This is my plaintext message" -tags "[['p', '4503baa127bdfd0b054384dc5ba82cb0e2a8367cbdb0629179f00db1a34caacc']]" -kind 4 --relay wss://relay.nostpy.lol wss://relay.damus.io wss://nos.lol
+nostpy-cli send_event -privkey 2b1e4e1f26517dda57458596760bb3bd3bd3717083763166e12983a6421abc18 -content "This is my plaintext message" -tags "[['p', '4503baa127bdfd0b054384dc5ba82cb0e2a8367cbdb0629179f00db1a34caacc']]" -kind 4 --relay wss://relay.nostpy.lol wss://relay.damus.io wss://nos.lol
 ```
 
 ### Query Event

--- a/nostpy_cli/main.py
+++ b/nostpy_cli/main.py
@@ -29,7 +29,7 @@ async def handle_send_event(args):
         kind4_codec = Kind4MessageCodec(args.private_key, args.tags[0][1])
         args.content = kind4_codec.encrypt_message(args.content)
     await event.send_event(
-        args.public_key, args.private_key, args.content, args.kind, args.tags
+        args.private_key, args.content, args.kind, args.tags
     )
 
 async def decrypt_message(args):
@@ -75,9 +75,6 @@ def main():
 
     # Subparser for the "send_event" command
     send_event_parser = subparsers.add_parser("send_event", help="Send an event")
-    send_event_parser.add_argument(
-        "-pubkey", "--public_key", required=True, help="Public key in hexadecimal"
-    )
     send_event_parser.add_argument(
         "-privkey", "--private_key", required=True, help="Private key in hexadecimal"
     )


### PR DESCRIPTION
The public key can be derived from the private key.