### PR TITLE
Use correct type for authors filter attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ nostpy-cli query --kinds "[1,9735]" --relay "wss://yourrelayurl.com"
 #### Example
 * Query an event with search
 ```
-nostpy-cli query -kinds "[31990,1]" -search "random_search" -since 1713629501 -authors npub1g5pm4gf8hh7skp2rsnw9h2pvkr32sdnuhkcx9yte7qxmrg6v4txqqudjqv --relay wss://relay.nostpy.lol
+nostpy-cli query -kinds "[31990,1]" -search "random_search" -since 1713629501 -authors aef0d6b212827f3ba1de6189613e6d4824f181f567b1205273c16895fdaf0b23 --relay wss://relay.nostpy.lol
 ```
 
 ### Decrypt kind4 message content

--- a/nostpy_cli/main.py
+++ b/nostpy_cli/main.py
@@ -60,7 +60,7 @@ def main():
         "-until", "--until", type=int, help="Collect events until"
     )
     query_parser.add_argument(
-        "-authors", "--authors", type=str, help="List of authors e.g. []"
+        "-authors", "--authors", nargs="+", type=str, help="List of authors e.g. []"
     )
     query_parser.add_argument(
         "-limit",


### PR DESCRIPTION
According to nip01 the authors attribute MUST be a list of 64-character lowercase hex values.